### PR TITLE
Added an optional local port definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ tunnel := sshtunnel.NewSSHTunnel(
 
    // The destination host and port of the actual server.
    "dqrsdfdssdfx.us-east-1.redshift.amazonaws.com:5439",
+   
+   // The local port you want to bind the remote port to.
+   // Specifying "0" will lead to a random port.
+   "8443",
 )
 
 // You can provide a logger for debugging, or remove this line to

--- a/ssh_tunnel.go
+++ b/ssh_tunnel.go
@@ -83,9 +83,13 @@ func (tunnel *SSHTunnel) Close() {
 	return
 }
 
-func NewSSHTunnel(tunnel string, auth ssh.AuthMethod, destination string) *SSHTunnel {
+func NewSSHTunnel(tunnel string, auth ssh.AuthMethod, destination string, localport ...string) *SSHTunnel {
 	// A random port will be chosen for us.
 	localEndpoint := NewEndpoint("localhost:0")
+
+	if len(localport) == 1 {
+		localEndpoint = NewEndpoint("localhost:" + localport[0])
+	}
 
 	server := NewEndpoint(tunnel)
 	if server.Port == 0 {

--- a/ssh_tunnel.go
+++ b/ssh_tunnel.go
@@ -83,13 +83,10 @@ func (tunnel *SSHTunnel) Close() {
 	return
 }
 
-func NewSSHTunnel(tunnel string, auth ssh.AuthMethod, destination string, localport ...string) *SSHTunnel {
-	// A random port will be chosen for us.
-	localEndpoint := NewEndpoint("localhost:0")
+// NewSSHTunnel creates a new single-use tunnel. Supplying "0" for localport will use a random port.
+func NewSSHTunnel(tunnel string, auth ssh.AuthMethod, destination string, localport string) *SSHTunnel {
 
-	if len(localport) == 1 {
-		localEndpoint = NewEndpoint("localhost:" + localport[0])
-	}
+	localEndpoint := NewEndpoint("localhost:"+localport)
 
 	server := NewEndpoint(tunnel)
 	if server.Port == 0 {


### PR DESCRIPTION
This commit simply adds the support for a local port definition when creating a tunnel.
The default will be to keep a random port unless specified.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/sshtunnel/4)
<!-- Reviewable:end -->
