### PR TITLE
Define minimal interface for tunnel logger

### DIFF
--- a/ssh_tunnel.go
+++ b/ssh_tunnel.go
@@ -2,18 +2,21 @@ package sshtunnel
 
 import (
 	"io"
-	"log"
 	"net"
 
 	"golang.org/x/crypto/ssh"
 )
+
+type logger interface {
+	Printf(string, ...interface{})
+}
 
 type SSHTunnel struct {
 	Local    *Endpoint
 	Server   *Endpoint
 	Remote   *Endpoint
 	Config   *ssh.ClientConfig
-	Log      *log.Logger
+	Log      logger
 	Conns    []net.Conn
 	SvrConns []*ssh.Client
 	isOpen   bool


### PR DESCRIPTION
Prior to this commit sshtunnel required the use of the standard
library's log package, even though it only used Printf. This commit
changes the struct to use an interface, which allows the consumer to
drop in a shim to the logger of their choice.

We'd like to be able to use our existing structured logger with sshtunnel; this changes allows us to do so.

Thanks for the incredibly helpful library.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/sshtunnel/9)
<!-- Reviewable:end -->
