### PR TITLE
Fix bug with unclosed ssh connection

### DIFF
--- a/ssh_tunnel.go
+++ b/ssh_tunnel.go
@@ -96,13 +96,14 @@ func (tunnel *SSHTunnel) forward(localConn net.Conn) {
 		return
 	}
 	tunnel.logf("connected to %s (1 of 2)\n", tunnel.Server.String())
+	tunnel.SvrConns = append(tunnel.SvrConns, serverConn)
+	
 	remoteConn, err := serverConn.Dial("tcp", tunnel.Remote.String())
 	if err != nil {
 		tunnel.logf("remote dial error: %s", err)
 		return
 	}
 	tunnel.Conns = append(tunnel.Conns, remoteConn)
-	tunnel.SvrConns = append(tunnel.SvrConns, serverConn)
 	tunnel.logf("connected to %s (2 of 2)\n", tunnel.Remote.String())
 	copyConn := func(writer, reader net.Conn) {
 		_, err := io.Copy(writer, reader)


### PR DESCRIPTION
Often there were unclosed SSH connections, later as it turned out, this was due to the fact that only those connections were added to the closures through which it was possible to establish a TCP connection.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/sshtunnel/13)
<!-- Reviewable:end -->
