### PR TITLE
Fix bug for parsing IPv6 addresses

### DIFF
--- a/endpoint.go
+++ b/endpoint.go
@@ -2,6 +2,7 @@ package sshtunnel
 
 import (
 	"fmt"
+	"net"
 	"strconv"
 	"strings"
 )
@@ -22,9 +23,10 @@ func NewEndpoint(s string) *Endpoint {
 		endpoint.Host = parts[1]
 	}
 
-	if parts := strings.Split(endpoint.Host, ":"); len(parts) > 1 {
-		endpoint.Host = parts[0]
-		endpoint.Port, _ = strconv.Atoi(parts[1])
+	host, port, err := net.SplitHostPort(endpoint.Host)
+	if err == nil {
+		endpoint.Host = host
+		endpoint.Port, _ = strconv.Atoi(port)
 	}
 
 	return endpoint

--- a/endpoint_test.go
+++ b/endpoint_test.go
@@ -1,0 +1,69 @@
+package sshtunnel_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/elliotchance/sshtunnel"
+)
+
+func TestCreateEndpoint(t *testing.T) {
+	// these are test cases for which we expect no error to occur when
+	// constructing endpoints i.e. they should be correct
+	testCases := []struct {
+		input            string
+		expectedEndpoint *sshtunnel.Endpoint
+	}{
+		{
+			"localhost:9000",
+			&sshtunnel.Endpoint{
+				Host: "localhost",
+				Port: 9000,
+				User: "",
+			},
+		},
+		{
+			"ec2-user@jumpbox.us-east-1.mydomain.com",
+			&sshtunnel.Endpoint{
+				Host: "jumpbox.us-east-1.mydomain.com",
+				Port: 0,
+				User: "ec2-user",
+			},
+		},
+		{
+			"dqrsdfdssdfx.us-east-1.redshift.amazonaws.com:5439",
+			&sshtunnel.Endpoint{
+				Host: "dqrsdfdssdfx.us-east-1.redshift.amazonaws.com",
+				Port: 5439,
+				User: "",
+			},
+		},
+		{
+			"admin@1.2.3.4:22", // IPv4 address
+			&sshtunnel.Endpoint{
+				Host: "1.2.3.4",
+				Port: 22,
+				User: "admin",
+			},
+		},
+		{
+			"admin@[2001:db8:1::ab9:C0A8:102]:22", // IPv6 address
+			&sshtunnel.Endpoint{
+				Host: "2001:db8:1::ab9:C0A8:102",
+				Port: 22,
+				User: "admin",
+			},
+		},
+	}
+	for i, tc := range testCases {
+		got, err := sshtunnel.NewEndpoint(tc.input)
+		if err != nil {
+			t.Errorf("unexpected error for correct input '%s': %v",
+				tc.input, err)
+		}
+		if !reflect.DeepEqual(got, tc.expectedEndpoint) {
+			t.Errorf("For test case %d, expected: %+v, got: %+v",
+				i, *tc.expectedEndpoint, *got)
+		}
+	}
+}

--- a/ssh_tunnel.go
+++ b/ssh_tunnel.go
@@ -147,15 +147,25 @@ func (tunnel *SSHTunnel) Close() {
 }
 
 // NewSSHTunnel creates a new single-use tunnel. Supplying "0" for localport will use a random port.
-func NewSSHTunnel(tunnel string, auth ssh.AuthMethod, destination string, localport string) *SSHTunnel {
+func NewSSHTunnel(tunnel string, auth ssh.AuthMethod, destination string, localport string) (*SSHTunnel, error) {
 
-	localEndpoint := NewEndpoint("localhost:" + localport)
+	localEndpoint, err := NewEndpoint("localhost:" + localport)
+	if err != nil {
+		return nil, err
+	}
 
-	server := NewEndpoint(tunnel)
+	server, err := NewEndpoint(tunnel)
+	if err != nil {
+		return nil, err
+	}
 	if server.Port == 0 {
 		server.Port = 22
 	}
 
+	remoteEndpoint, err := NewEndpoint(destination)
+	if err != nil {
+		return nil, err
+	}
 	sshTunnel := &SSHTunnel{
 		Config: &ssh.ClientConfig{
 			User: server.User,
@@ -167,9 +177,9 @@ func NewSSHTunnel(tunnel string, auth ssh.AuthMethod, destination string, localp
 		},
 		Local:  localEndpoint,
 		Server: server,
-		Remote: NewEndpoint(destination),
+		Remote: remoteEndpoint,
 		close:  make(chan interface{}),
 	}
 
-	return sshTunnel
+	return sshTunnel, nil
 }


### PR DESCRIPTION
IPv6 addresses contain colons ':' and since sshtunnel uses `strings.Split(addr, ":")`, to spit host and port, it ends up resulting in faulty splits. Using `net.SplitHostPort` fixes this since it handles IPv6 addresses correctly. If the user did not supply a port, then `endpoint.Host` is left as is.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/sshtunnel/17)
<!-- Reviewable:end -->
